### PR TITLE
add custom partial option for #abyme_records

### DIFF
--- a/lib/abyme/view_helpers.rb
+++ b/lib/abyme/view_helpers.rb
@@ -17,7 +17,6 @@ module Abyme
     end
   
     def abyme_records(form, association, options = { order: {} })
-  
       if options[:collection]
         records = options[:collection]
       else
@@ -37,7 +36,11 @@ module Abyme
   
       form.fields_for association, records do |f|
         content_tag(:div, class: 'abyme--fields') do
-          render("#{association.to_s.singularize}_fields", f: f)
+          if options[:partial]
+            render(options[:partial], f: f)
+          else
+            render("#{association.to_s.singularize}_fields", f: f)
+          end
         end
       end
     end


### PR DESCRIPTION
### #abyme_records minor tweak
added custom partial path option for #abyme_records helper method
same behavior as #abymize

you can now pass a partial key to indicate the partial file you want:

<img width="786" alt="Capture d’écran 2020-10-09 à 00 11 04" src="https://user-images.githubusercontent.com/34983046/95518795-1e359480-09c4-11eb-852e-2d30bcf00498.png">

