### PR TITLE
add specs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,7 @@ group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
   gem 'rspec-rails'
   gem 'capybara', '>= 2.15'
+  gem 'launchy'
   gem 'selenium-webdriver'
   gem 'webdrivers', '~> 4.0'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,6 +94,8 @@ GEM
       concurrent-ruby (~> 1.0)
     jbuilder (2.10.1)
       activesupport (>= 5.0.0)
+    launchy (2.5.0)
+      addressable (~> 2.7)
     listen (3.2.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -243,6 +245,7 @@ DEPENDENCIES
   factory_bot_rails
   font-awesome-sass (~> 5.13.0)
   jbuilder (~> 2.7)
+  launchy
   listen (~> 3.2)
   pg (>= 0.18, < 2.0)
   puma (~> 4.1)

--- a/app/views/projects/_form.html.erb
+++ b/app/views/projects/_form.html.erb
@@ -16,14 +16,14 @@
 			<%= f.submit 'Save', class: 'main-btn text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline w-full cursor-pointer' %>
 
 			<div class="w-full p-6">
-				<%= abymize(:participants, f) %>
+				<%= abymize(:participants, f, add: 'add participant', html: { class: 'participant-fields' }) %>
 			</div>
 		</div>
 		<div class="container bg-white p-8 w-2/3 ml-3">
 			<%= abymize(:tasks, f) do |abyme| %>
         <%= abyme.records(order: {created_at: :asc}) %>
 				<%= abyme.new_records(position: :end, partial: 'projects/task_fields') %>
-				<%= add_association(content: '+', tag: :div, attributes: { id: 'add-task' }) %>
+				<%= add_association(content: '+', tag: :div, html: { id: 'add-task' }) %>
 			<% end %>
 		</div>
 	</div>

--- a/app/views/projects/_task_fields.html.erb
+++ b/app/views/projects/_task_fields.html.erb
@@ -1,4 +1,4 @@
-<div class="border-solid border-2 rounded border-blue-300 bg-white rounded-b lg:rounded-b-none lg:rounded-r p-4 flex flex-col justify-between leading-normal p-8 my-5">
+<div class="custom-partial border-solid border-2 rounded border-blue-300 bg-white rounded-b lg:rounded-b-none lg:rounded-r p-4 flex flex-col justify-between leading-normal p-8 my-5">
   <div class="flex align-center justify-between">
     <div class="w-1/2 p-6">
 	    <div class="field mb-4">

--- a/app/views/shared/_task_fields.html.erb
+++ b/app/views/shared/_task_fields.html.erb
@@ -1,4 +1,4 @@
-<div class="border-solid border-2 rounded border-gray-300 bg-white rounded-b lg:rounded-b-none lg:rounded-r p-4 flex flex-col justify-between leading-normal p-8 my-5">
+<div class="default-partial border-solid border-2 rounded border-gray-300 bg-white rounded-b lg:rounded-b-none lg:rounded-r p-4 flex flex-col justify-between leading-normal p-8 my-5">
   <div class="flex align-center justify-between">
     <div class="w-1/2 p-6">
 	    <div class="field mb-4">

--- a/spec/support/helpers/add_nested_attributes.rb
+++ b/spec/support/helpers/add_nested_attributes.rb
@@ -6,6 +6,13 @@ def add_tasks(number = 2)
   descriptions.each_with_index {|title, n| title.fill_in(with: "Small description for task number #{n + 1}") }
 end
 
+def add_tasks_with_errors(number = 2)
+  number.times { find("div", id: "add-task").click }
+  titles = find_all_by_id('input', /project_tasks_attributes_\d*_title/)
+  descriptions = find_all_by_id('textarea', /project_tasks_attributes_\d*_description/ )
+  descriptions.each_with_index {|title, n| title.fill_in(with: "Small description for task number #{n + 1}") }
+end
+
 def fill_project_fields(title)
   fill_in('project_title', with: title)
   fill_in('project_description', with: "La mise en abyme — également orthographiée mise en abysme ou plus rarement mise en abîme1 — est un procédé consistant à représenter une œuvre dans une œuvre similaire, par exemple dans les phénomènes de « film dans un film », ou encore en incrustant dans une image cette image elle-même (en réduction).")
@@ -19,8 +26,8 @@ def add_comments(number = 2)
 end
 
 def add_participants(number = 2)
-  number.times { click_on("Add Participant") }
-  within('div[data-model="participants"]') do
+  number.times { click_on('add participant') }
+  within('div[data-association="participants"]') do
     emails = all("input")
     emails.each_with_index {|input, index| input.fill_in(with: "email_#{index}@gmail.com") }
   end

--- a/spec/system/nested_attributes_spec.rb
+++ b/spec/system/nested_attributes_spec.rb
@@ -80,6 +80,77 @@ RSpec.describe "Nested attributes behaviour", type: :system do
   end
 end
 
+RSpec.describe "HTML attributes for 'abyme-fields' & add/remove association", type: :system do
+  it 'should create the correct id' do
+    visit new_project_path
+    element = page.find('#add-task')
+    expect(element).should_not be_nil
+  end
+
+  it 'should create the correct classes' do 
+    visit new_project_path
+    click_on('add participant')
+    element = page.find('.participant-fields')
+    expect(element).should_not be_nil
+  end
+
+  it 'should add the base class "abyme--fields"' do
+    visit new_project_path
+    click_on('add participant')
+    element = page.find('.abyme--fields')
+    expect(element).should_not be_nil
+  end
+
+  it 'should set the correct inner text for the add association button' do
+    visit new_project_path
+    element = page.find('button', text: 'add participant')
+    expect(element).should_not be_nil
+  end
+end
+
+RSpec.describe "Partials default & custom path", type: :system do
+  it 'should set the correct partial when path specified' do
+    visit new_project_path
+    add_tasks(1)
+    element = page.find('.custom-partial')
+    expect(element).should_not be_nil
+  end
+
+  it 'should set the correct partial when path not specified' do
+    visit new_project_path
+    fill_in('project_title', with: "A project with two tasks")
+    fill_in('project_description', with: 'A project description')    
+    add_tasks(1)
+    click_on('Save')
+    visit edit_project_path(Project.last)
+    element = page.find('.default-partial')
+    expect(element).should_not be_nil
+  end
+end
+
+RSpec.describe "Render error feedback", type: :system do
+  it 'should render error feedback for main resource' do
+    visit new_project_path
+    fill_in('project_description', with: 'A project description')
+    click_on('Save')
+    save_and_open_page
+    element = page.find('.error')
+    expect(element).should_not be_nil
+  end
+
+  it 'should render error feedback for nested resources' do
+    visit new_project_path
+    fill_in('project_title', with: "A project with two tasks")
+    fill_in('project_description', with: 'A project description')
+    add_tasks(1)
+    add_tasks_with_errors(1)
+    click_on('Save')
+    save_and_open_page
+    element = page.find('.error')
+    expect(element).should_not be_nil
+  end
+end
+
 def find_all_by_id(element, matcher)
   all(element) {|el| el[:id].match? matcher }
 end


### PR DESCRIPTION
### **Naming**
the attributes option has changed to html for syntax purpose, you can now pass html attributes for both abymize abyme.records & abyme.new_records this way: 

<img width="1024" alt="Capture d’écran 2020-10-12 à 12 34 36" src="https://user-images.githubusercontent.com/34983046/95736999-502a4d80-0c87-11eb-91d4-29a39f4429f0.png">

+ you can now add html attributes to the abyme--fields div

### Tests
added some specs for html attributes, partials and error feedbacks 

