### PR TITLE
add limit option

### DIFF
--- a/app/javascript/controllers/abyme_controller.js
+++ b/app/javascript/controllers/abyme_controller.js
@@ -1,7 +1,7 @@
 import { Controller } from 'stimulus';
 
 export default class extends Controller {
-  static targets = ['template', 'associations'];
+  static targets = ['template', 'associations', 'fields'];
 
   connect() {
     console.log('Abyme Connect');
@@ -14,47 +14,43 @@ export default class extends Controller {
   add_association(event) {
     event.preventDefault();
 
-    let html = this.templateTarget.innerHTML.replace(
-      /NEW_RECORD/g,
-      new Date().getTime()
-    );
-
-    if (html.match(/<template[\s\S]+<\/template>/)) {
-      const template = html
-        .match(/<template[\s\S]+<\/template>/)[0]
-        .replace(/(\[\d{12,}\])(\[[^\[\]]+\]"){1}/g, `[NEW_RECORD]$2`);
-
-      html = html.replace(/<template[\s\S]+<\/template>/g, template);
+    // check for limit reached
+    if (this.element.dataset.limit && this.limit_check()) {
+      this.create_event('limit-reached')
+      return false
     }
 
-    this.create_event('before-add', html)
+
+    const html = this.build_html();
+    this.create_event('before-add');
     this.associationsTarget.insertAdjacentHTML(this.position, html);
-    this.create_event('after-add', html)
+    this.create_event('after-add');
   }
 
   remove_association(event) {
     event.preventDefault();
 
-    this.create_event('before-remove')
-    let wrapper = event.target.closest('.abyme--fields');
-    wrapper.querySelector("input[name*='_destroy']").value = 1;
-    wrapper.style.display = 'none';
-    this.create_event('after-remove')
+
+    this.create_event('before-remove');
+    this.mark_for_destroy(event);
+    this.create_event('after-remove');
   }
 
+  // LIFECYCLE EVENTS RELATED
+
   create_event(stage, html = null) {
-    const event = new CustomEvent(`abyme:${stage}`, { detail: {controller: this, content: html} })
-    this.element.dispatchEvent(event)
+    const event = new CustomEvent(`abyme:${stage}`, { detail: {controller: this, content: html} });
+    this.element.dispatchEvent(event);
     // WIP
-    this.dispatch(event, stage)
+    this.dispatch(event, stage);
   }
 
   // WIP : Trying to integrate event handling through controller inheritance
   dispatch(event, stage) {
-    if (stage === 'before-add' && this.abymeBeforeAdd) this.abymeBeforeAdd(event)
-    if (stage === 'after-add' && this.abymeAfterAdd) this.abymeAfterAdd(event)
-    if (stage === 'before-remove' && this.abymeBeforeRemove) this.abymeBeforeAdd(event)
-    if (stage === 'after-remove' && this.abymeAfterRemove) this.abymeAfterRemove(event)
+    if (stage === 'before-add' && this.abymeBeforeAdd) this.abymeBeforeAdd(event);
+    if (stage === 'after-add' && this.abymeAfterAdd) this.abymeAfterAdd(event);
+    if (stage === 'before-remove' && this.abymeBeforeRemove) this.abymeBeforeAdd(event);
+    if (stage === 'after-remove' && this.abymeAfterRemove) this.abymeAfterRemove(event);
   }
 
   abymeBeforeAdd(event) {
@@ -67,5 +63,40 @@ export default class extends Controller {
   }
 
   abymeAfterRemove(event) {
+  }
+
+  // UTILITIES
+
+  // build html
+  build_html() {
+    let html = this.templateTarget.innerHTML.replace(
+      /NEW_RECORD/g,
+      new Date().getTime()
+    );
+      
+    if (html.match(/<template[\s\S]+<\/template>/)) {
+      const template = html
+      .match(/<template[\s\S]+<\/template>/)[0]
+      .replace(/(\[\d{12,}\])(\[[^\[\]]+\]"){1}/g, `[NEW_RECORD]$2`);
+      
+      html = html.replace(/<template[\s\S]+<\/template>/g, template);
+    }
+
+    return html;
+  }
+    
+  // mark association for destroy
+  mark_for_destroy(event) {
+    let item = event.target.closest('.abyme--fields');
+    item.querySelector("input[name*='_destroy']").value = 1;
+    item.style.display = 'none';
+    item.classList.add('abyme--marked-for-destroy')
+  }
+
+  // check if associations limit is reached
+  limit_check() {
+    return (this.fieldsTargets
+                .filter(item => !item.classList.contains('abyme--marked-for-destroy'))).length 
+                >= parseInt(this.element.dataset.limit)
   }
 }

--- a/app/views/projects/_form.html.erb
+++ b/app/views/projects/_form.html.erb
@@ -20,7 +20,7 @@
 			</div>
 		</div>
 		<div class="container bg-white p-8 w-2/3 ml-3">
-			<%= abymize(:tasks, f) do |abyme| %>
+			<%= abymize(:tasks, f, limit: 3) do |abyme| %>
         <%= abyme.records(order: {created_at: :asc}) %>
 				<%= abyme.new_records(position: :end, partial: 'projects/task_fields') %>
 				<%= add_association(content: '+', tag: :div, html: { id: 'add-task' }) %>

--- a/lib/abyme/view_helpers.rb
+++ b/lib/abyme/view_helpers.rb
@@ -2,7 +2,7 @@ module Abyme
   module ViewHelpers
 
     def abymize(association, form, options = {}, &block)
-      content_tag(:div, data: { controller: 'abyme' }, id: "abyme--#{association}") do
+      content_tag(:div, data: { controller: 'abyme', limit: options[:limit] }, id: "abyme--#{association}") do
         if block_given?
           yield(Abyme::AbymeBuilder.new(association: association, form: form, lookup_context: self.lookup_context))
         else
@@ -18,7 +18,7 @@ module Abyme
       content_tag(:div, data: { target: 'abyme.associations', association: association, abyme_position: options[:position] || :end }) do
         content_tag(:template, class: "abyme--#{association.to_s.singularize}_template", data: { target: 'abyme.template' }) do
           form.fields_for association, association.to_s.classify.constantize.new, child_index: 'NEW_RECORD' do |f|
-            content_tag(:div, basic_markup(options[:html])) do
+            content_tag(:div, basic_markup(options[:html]).merge(data: { target: 'abyme.fields' })) do
               # Here, if a block is passed, we're passing the association fields to it, rather than the form itself
               block_given? ? yield(f) : render("abyme/#{association.to_s.singularize}_fields", f: f)
             end
@@ -38,7 +38,7 @@ module Abyme
       end
 
       form.fields_for(association, records) do |f|
-        content_tag(:div, basic_markup(options[:html])) do
+        content_tag(:div, basic_markup(options[:html]).merge(data: { target: 'abyme.fields' })) do
           block_given? ? yield(f) : render("abyme/#{association.to_s.singularize}_fields", f: f)
         end
       end


### PR DESCRIPTION
### **limit feature**
added a limit feature to set a maximum number of associations fields to display.
you can now set the limit on the top level wrapper (abymize): 

<img width="511" alt="Capture d’écran 2020-10-14 à 01 11 56" src="https://user-images.githubusercontent.com/34983046/95925681-b9f74400-0dba-11eb-8530-95fb2c0bdf06.png">

it make more sense to set the limit on the abymize level because the limit will apply for both records & new_records

### JS
a new custom event (abyme:limit-reached) is now fired when the maximum number of associations fields is reached

plus some refacto of the AbymeController to make the code more clear
