### PR TITLE
Min-count, Partial option for #abymize, and default class

### DIFF
--- a/app/javascript/controllers/abyme_controller.js
+++ b/app/javascript/controllers/abyme_controller.js
@@ -4,22 +4,28 @@ export default class extends Controller {
   static targets = ['template', 'associations', 'fields'];
 
   connect() {
-    console.log('Abyme Connect');
+    if (this.count) {
+      this.addDefaultAssociations();
+    }
   }
 
+  get count() {
+    return this.element.dataset.minCount || 0;
+  }
+  
   get position() {
     return this.associationsTarget.dataset.abymePosition === 'end' ? 'beforeend' : 'afterbegin';
   }
 
   add_association(event) {
-    event.preventDefault();
-
+    if (event) {
+      event.preventDefault();
+    }
     // check for limit reached
     if (this.element.dataset.limit && this.limit_check()) {
       this.create_event('limit-reached')
       return false
     }
-
 
     const html = this.build_html();
     this.create_event('before-add');
@@ -29,8 +35,6 @@ export default class extends Controller {
 
   remove_association(event) {
     event.preventDefault();
-
-
     this.create_event('before-remove');
     this.mark_for_destroy(event);
     this.create_event('after-remove');
@@ -98,5 +102,21 @@ export default class extends Controller {
     return (this.fieldsTargets
                 .filter(item => !item.classList.contains('abyme--marked-for-destroy'))).length 
                 >= parseInt(this.element.dataset.limit)
+  }
+
+  // Add default blank associations at page load
+  async addDefaultAssociations() {
+    let i = 0
+    while (i < this.count) {
+      this.add_association()
+      console.log("coucou")
+      i++
+      // Sleep function to ensure uniqueness of timestamp
+      await this.sleep(1);
+    }
+  }
+
+  sleep(ms) {
+    return new Promise(resolve => setTimeout(resolve, ms));
   }
 }

--- a/app/views/abyme/_task_fields.html.erb
+++ b/app/views/abyme/_task_fields.html.erb
@@ -1,4 +1,4 @@
-<div class="default-partial border-solid border-2 rounded border-gray-300 bg-white rounded-b lg:rounded-b-none lg:rounded-r p-4 flex flex-col justify-between leading-normal p-8 my-5">
+<div class="default-partial border-solid border-2 rounded border-blue-300 bg-white rounded-b lg:rounded-b-none lg:rounded-r p-4 flex flex-col justify-between leading-normal p-8 my-5">
   <div class="flex align-center justify-between">
     <div class="w-1/2 p-6">
 	    <div class="field mb-4">
@@ -24,7 +24,7 @@
       <% end %>
     </div>
     <div class="w-1/2 border-solid border-2 rounded border-gray-300">
-      <%= abymize(:comments, f) %>
+      <%= abymize(:comments, f, min_count: 1) %>
     </div>
   </div>
 </div>

--- a/app/views/projects/_form.html.erb
+++ b/app/views/projects/_form.html.erb
@@ -20,9 +20,9 @@
 			</div>
 		</div>
 		<div class="container bg-white p-8 w-2/3 ml-3">
-			<%= abymize(:tasks, f, limit: 3) do |abyme| %>
+			<%= abymize(:tasks, f, limit: 3, partial: 'projects/task_fields') do |abyme| %>
         <%= abyme.records(order: {created_at: :asc}) %>
-				<%= abyme.new_records(position: :end, partial: 'projects/task_fields') %>
+				<%= abyme.new_records(position: :end) %>
 				<%= add_association(content: 'Add task', html: { id: 'add-task' }) %>
 			<% end %>
 		</div>

--- a/app/views/projects/_form.html.erb
+++ b/app/views/projects/_form.html.erb
@@ -23,7 +23,7 @@
 			<%= abymize(:tasks, f, limit: 3) do |abyme| %>
         <%= abyme.records(order: {created_at: :asc}) %>
 				<%= abyme.new_records(position: :end, partial: 'projects/task_fields') %>
-				<%= add_association(content: '+', tag: :div, html: { id: 'add-task' }) %>
+				<%= add_association(content: 'Add task', html: { id: 'add-task' }) %>
 			<% end %>
 		</div>
 	</div>

--- a/app/views/projects/_task_fields.html.erb
+++ b/app/views/projects/_task_fields.html.erb
@@ -24,7 +24,7 @@
       <% end %>
     </div>
     <div class="w-1/2 border-solid border-2 rounded border-gray-300">
-      <%= abymize(:comments, f) %>
+      <%= abymize(:comments, f, min_count: 1) %>
     </div>
   </div>
 </div>

--- a/lib/abyme/abyme_builder.rb
+++ b/lib/abyme/abyme_builder.rb
@@ -2,10 +2,11 @@ module Abyme
   class AbymeBuilder < ActionView::Base
     include ActionView
 
-    def initialize(association:, form:, lookup_context:, &block)
+    def initialize(association:, form:, lookup_context:, partial:, &block)
       @association = association
       @form = form
       @lookup_context = lookup_context
+      @partial = partial
       yield(self) if block_given?
     end
   
@@ -24,7 +25,7 @@ module Abyme
     private
 
     def render_association_partial(fields, options)
-      partial = options[:partial] || "abyme/#{@association.to_s.singularize}_fields"
+      partial = @partial || options[:partial] || "abyme/#{@association.to_s.singularize}_fields"
       ActionController::Base.render(partial: partial, locals: { f: fields })
     end
   end

--- a/lib/abyme/view_helpers.rb
+++ b/lib/abyme/view_helpers.rb
@@ -2,9 +2,12 @@ module Abyme
   module ViewHelpers
 
     def abymize(association, form, options = {}, &block)
-      content_tag(:div, data: { controller: 'abyme', limit: options[:limit] }, id: "abyme--#{association}") do
+      content_tag(:div, data: { controller: 'abyme', limit: options[:limit], min_count: options[:min_count] }, id: "abyme--#{association}") do
         if block_given?
-          yield(Abyme::AbymeBuilder.new(association: association, form: form, lookup_context: self.lookup_context))
+          yield(Abyme::AbymeBuilder.new(
+            association: association, form: form, lookup_context: self.lookup_context, partial: options[:partial]
+            )
+          )
         else
           model = association.to_s.singularize.classify.constantize
           concat(persisted_records_for(association, form, options))
@@ -17,8 +20,9 @@ module Abyme
     def new_records_for(association, form, options = {}, &block)
       content_tag(:div, data: { target: 'abyme.associations', association: association, abyme_position: options[:position] || :end }) do
         content_tag(:template, class: "abyme--#{association.to_s.singularize}_template", data: { target: 'abyme.template' }) do
+
           form.fields_for association, association.to_s.classify.constantize.new, child_index: 'NEW_RECORD' do |f|
-            content_tag(:div, basic_markup(options[:html]).merge(data: { target: 'abyme.fields' })) do
+            content_tag(:div, basic_markup(options[:html], association).merge(data: { target: 'abyme.fields' })) do
               # Here, if a block is passed, we're passing the association fields to it, rather than the form itself
               block_given? ? yield(f) : render("abyme/#{association.to_s.singularize}_fields", f: f)
             end
@@ -38,7 +42,7 @@ module Abyme
       end
 
       form.fields_for(association, records) do |f|
-        content_tag(:div, basic_markup(options[:html]).merge(data: { target: 'abyme.fields' })) do
+        content_tag(:div, basic_markup(options[:html], association).merge(data: { target: 'abyme.fields' })) do
           block_given? ? yield(f) : render("abyme/#{association.to_s.singularize}_fields", f: f)
         end
       end
@@ -70,12 +74,12 @@ module Abyme
       end
     end
 
-    def basic_markup(html)
+    def basic_markup(html, association = nil)
       if html && html[:class]
-        html[:class] = 'abyme--fields ' + html[:class]
+        html[:class] = "abyme--fields #{association.to_s.singularize}-fields #{html[:class]}" 
       else
         html ||= {}
-        html[:class] = 'abyme--fields'
+        html[:class] = "abyme--fields #{association.to_s.singularize}-fields"
       end
       html
     end

--- a/spec/support/helpers/add_nested_attributes.rb
+++ b/spec/support/helpers/add_nested_attributes.rb
@@ -1,5 +1,5 @@
 def add_tasks(number = 2)
-  number.times { find("div", id: "add-task").click }
+  number.times { find_by_id("add-task").click }
   titles = find_all_by_id('input', /project_tasks_attributes_\d*_title/)
   descriptions = find_all_by_id('textarea', /project_tasks_attributes_\d*_description/ )
   titles.each_with_index {|title, n| title.fill_in(with: "Task #{n + 1}") }
@@ -7,7 +7,7 @@ def add_tasks(number = 2)
 end
 
 def add_tasks_with_errors(number = 2)
-  number.times { find("div", id: "add-task").click }
+  number.times { find_by_id("add-task").click }
   titles = find_all_by_id('input', /project_tasks_attributes_\d*_title/)
   descriptions = find_all_by_id('textarea', /project_tasks_attributes_\d*_description/ )
   descriptions.each_with_index {|title, n| title.fill_in(with: "Small description for task number #{n + 1}") }

--- a/spec/system/abyme_options_spec.rb
+++ b/spec/system/abyme_options_spec.rb
@@ -1,44 +1,81 @@
 require "rails_helper"
-
-RSpec.describe "Partials default & custom path", type: :system do
-  it 'should set the correct partial when path specified' do
-    visit new_project_path
-    add_tasks(1)
-    element = page.find('.custom-partial')
-    expect(element).should_not be_nil
+RSpec.describe "Helper options" do
+  describe "Partials default & custom path", type: :system do
+    it 'should set the correct partial when path specified' do
+      visit new_project_path
+      add_tasks(1)
+      element = page.find('.custom-partial')
+      expect(element).should_not be_nil
+    end
+  
+    it 'should set the correct partial when path not specified' do
+      visit new_project_path
+      fill_in('project_title', with: "A project with two tasks")
+      fill_in('project_description', with: 'A project description')    
+      add_tasks(1)
+      click_on('Save')
+      visit edit_project_path(Project.last)
+      element = page.find('.default-partial')
+      expect(element).should_not be_nil
+    end
+  end
+  
+  describe "Render error feedback", type: :system do
+    it 'should render error feedback for main resource' do
+      visit new_project_path
+      fill_in('project_description', with: 'A project description')
+      click_on('Save')
+      save_and_open_page
+      element = page.find('.error')
+      expect(element).should_not be_nil
+    end
+  
+    it 'should render error feedback for nested resources' do
+      visit new_project_path
+      fill_in('project_title', with: "A project with two tasks")
+      fill_in('project_description', with: 'A project description')
+      add_tasks(1)
+      add_tasks_with_errors(1)
+      click_on('Save')
+      save_and_open_page
+      element = page.find('.error')
+      expect(element).should_not be_nil
+    end
   end
 
-  it 'should set the correct partial when path not specified' do
-    visit new_project_path
-    fill_in('project_title', with: "A project with two tasks")
-    fill_in('project_description', with: 'A project description')    
-    add_tasks(1)
-    click_on('Save')
-    visit edit_project_path(Project.last)
-    element = page.find('.default-partial')
-    expect(element).should_not be_nil
-  end
-end
+  describe "HTML attributes for 'abyme-fields' & add/remove association", type: :system do
+    it 'should create the correct id' do
+      visit new_project_path
+      element = page.find('#add-task')
+      expect(element).should_not be_nil
+    end
+  
+    it 'should create the correct classes' do 
+      visit new_project_path
+      click_on('add participant')
+      element = page.find('.participant-fields')
+      expect(element).should_not be_nil
+    end
+  
+    it 'should add the base class "abyme--fields"' do
+      visit new_project_path
+      click_on('add participant')
+      element = page.find('.abyme--fields')
+      expect(element).should_not be_nil
+    end
+  
+    it 'should set the correct inner text for the add association button' do
+      visit new_project_path
+      element = page.find('button', text: 'add participant')
+      expect(element).should_not be_nil
+    end
 
-RSpec.describe "Render error feedback", type: :system do
-  it 'should render error feedback for main resource' do
-    visit new_project_path
-    fill_in('project_description', with: 'A project description')
-    click_on('Save')
-    save_and_open_page
-    element = page.find('.error')
-    expect(element).should_not be_nil
-  end
-
-  it 'should render error feedback for nested resources' do
-    visit new_project_path
-    fill_in('project_title', with: "A project with two tasks")
-    fill_in('project_description', with: 'A project description')
-    add_tasks(1)
-    add_tasks_with_errors(1)
-    click_on('Save')
-    save_and_open_page
-    element = page.find('.error')
-    expect(element).should_not be_nil
+    it 'should not create more than 3 tasks' do
+      visit new_project_path
+      4.times { click_on('Add task') }
+      task_fields = []
+      within('#abyme--tasks') { task_fields = all('.abyme--fields') }
+      expect(task_fields.length).to eq(3)
+    end
   end
 end

--- a/spec/system/abyme_options_spec.rb
+++ b/spec/system/abyme_options_spec.rb
@@ -5,18 +5,15 @@ RSpec.describe "Helper options" do
       visit new_project_path
       add_tasks(1)
       element = page.find('.custom-partial')
-      expect(element).should_not be_nil
+      expect(element).not_to be_nil
     end
   
     it 'should set the correct partial when path not specified' do
       visit new_project_path
-      fill_in('project_title', with: "A project with two tasks")
-      fill_in('project_description', with: 'A project description')    
-      add_tasks(1)
-      click_on('Save')
-      visit edit_project_path(Project.last)
-      element = page.find('.default-partial')
-      expect(element).should_not be_nil
+      click_on('add participant')
+      within('#abyme--participants') do
+        expect(".abyme--fields").not_to be_nil
+      end
     end
   end
   
@@ -27,7 +24,7 @@ RSpec.describe "Helper options" do
       click_on('Save')
       save_and_open_page
       element = page.find('.error')
-      expect(element).should_not be_nil
+      expect(element).not_to be_nil
     end
   
     it 'should render error feedback for nested resources' do
@@ -39,7 +36,7 @@ RSpec.describe "Helper options" do
       click_on('Save')
       save_and_open_page
       element = page.find('.error')
-      expect(element).should_not be_nil
+      expect(element).not_to be_nil
     end
   end
 
@@ -47,35 +44,42 @@ RSpec.describe "Helper options" do
     it 'should create the correct id' do
       visit new_project_path
       element = page.find('#add-task')
-      expect(element).should_not be_nil
+      expect(element).not_to be_nil
     end
   
     it 'should create the correct classes' do 
       visit new_project_path
       click_on('add participant')
       element = page.find('.participant-fields')
-      expect(element).should_not be_nil
+      expect(element).not_to be_nil
     end
   
-    it 'should add the base class "abyme--fields"' do
+    it 'should add the base classes "abyme--fields" and "association-fields' do
       visit new_project_path
       click_on('add participant')
-      element = page.find('.abyme--fields')
-      expect(element).should_not be_nil
+      element = page.find('.abyme--fields.participant-fields')
+      expect(element).not_to be_nil
     end
   
     it 'should set the correct inner text for the add association button' do
       visit new_project_path
       element = page.find('button', text: 'add participant')
-      expect(element).should_not be_nil
+      expect(element).not_to be_nil
     end
 
     it 'should not create more than 3 tasks' do
       visit new_project_path
       4.times { click_on('Add task') }
       task_fields = []
-      within('#abyme--tasks') { task_fields = all('.abyme--fields') }
-      expect(task_fields.length).to eq(3)
+      within('#abyme--tasks') { expect(all('.task-fields').length).to eq(3) }
+    end
+    
+    it 'should display 1 default empty comment per task' do
+      visit new_project_path
+      click_on('Add task')
+      within('#abyme--comments') do
+        expect(find('.comment-fields')).not_to be_nil
+      end 
     end
   end
 end

--- a/spec/system/nested_attributes_spec.rb
+++ b/spec/system/nested_attributes_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe "Nested attributes behaviour", type: :system do
       add_tasks
       add_comments
       click_on('Save')
-      expect(Project.last.comments.count).to eq(4)
+      expect(Project.last.comments.count).to eq(6)
     end
 
     it "creates a project along with participants, using the #abyme_for method without any block/option", js: true do
@@ -55,7 +55,7 @@ RSpec.describe "Nested attributes behaviour", type: :system do
     it 'updates a project by adding a few tasks', js: true do
       visit edit_project_path(@project)
       add_tasks(3)
-      add_comments(3)
+      add_comments(2)
       click_on('Save')
       @project.reload
       expect(@project.tasks.count).to eq(3)
@@ -79,6 +79,7 @@ RSpec.describe "Nested attributes behaviour", type: :system do
     end
   end
 end
+
 
 def find_all_by_id(element, matcher)
   all(element) {|el| el[:id].match? matcher }

--- a/spec/system/nested_attributes_spec.rb
+++ b/spec/system/nested_attributes_spec.rb
@@ -80,34 +80,6 @@ RSpec.describe "Nested attributes behaviour", type: :system do
   end
 end
 
-RSpec.describe "HTML attributes for 'abyme-fields' & add/remove association", type: :system do
-  it 'should create the correct id' do
-    visit new_project_path
-    element = page.find('#add-task')
-    expect(element).should_not be_nil
-  end
-
-  it 'should create the correct classes' do 
-    visit new_project_path
-    click_on('add participant')
-    element = page.find('.participant-fields')
-    expect(element).should_not be_nil
-  end
-
-  it 'should add the base class "abyme--fields"' do
-    visit new_project_path
-    click_on('add participant')
-    element = page.find('.abyme--fields')
-    expect(element).should_not be_nil
-  end
-
-  it 'should set the correct inner text for the add association button' do
-    visit new_project_path
-    element = page.find('button', text: 'add participant')
-    expect(element).should_not be_nil
-  end
-end
-
 def find_all_by_id(element, matcher)
   all(element) {|el| el[:id].match? matcher }
 end


### PR DESCRIPTION
## Min-count
Added possibility of passing a minimum number of blank records. When passing a `min_count:` option to `abymize`, a dataset gets set on the container, which we then user in Stimulus to trigger the `add_association` as many times as needed.

## Partial option in #abymize 
Added option for abymize so that we only pass the custom partial path once, instead of both `records` and `new_records` methods. They still retain the possibility of being passed a custom partial directly, should the user want to use a different one for each.

## Default class to easily target fields
Added a more specific `singular_association-fields` class to every fields (in addition to the `abyme--fields` class. It will probably save the need of passing a custom class to target those (not everyone is wise enough to use Tailwind 🤓)

## Reorganized specs
We now have 2 different spec files :
- One for the broad integration tests that save stuff to DB and tests the whole MVC pattern
- One for the smaller tests which mainly test the different helper options. This one will be a very good start for our gem test 💯 