### PR TITLE
Data-attributes in html options

### DIFF
--- a/app/views/projects/_form.html.erb
+++ b/app/views/projects/_form.html.erb
@@ -21,7 +21,10 @@
 		<div class="container bg-white p-8 w-2/3 ml-3">
 			<%= abymize(:tasks, f, limit: 3, partial: 'projects/task_fields') do |abyme| %>
         <%= abyme.records(order: {created_at: :asc}, wrapper_html: { class: "persisted-tasks" }) %>
-				<%= abyme.new_records(position: :end, wrapper_html: {class: "new-tasks", data: { target: 'wrapper-target', controller: 'wrapper-controller' }}, fields_html: {class: "random-field-class", data: { target: 'sub-target', controller: 'sub-controller' }}) %>
+				<%= abyme.new_records(position: :end, 
+					wrapper_html: { class: "new-tasks", data: { target: 'wrapper-target', controller: 'tasks-wrapper' } },
+					fields_html: {class: "test", data: { target: 'sub-target', controller: 'sub-controller' } }
+				) %>
 				<%= add_association(content: 'Add task', html: { id: 'add-task', class: 'border-solid border-2 rounded border-grey-300 bg-white rounded-b lg:rounded-b-none lg:rounded-r p-4 flex flex-col justify-center items-center leading-normal p-8 my-5 cursor-pointer w-full focus:outline-none' }) %>
 			<% end %>
 		</div>

--- a/app/views/projects/_form.html.erb
+++ b/app/views/projects/_form.html.erb
@@ -21,7 +21,7 @@
 		<div class="container bg-white p-8 w-2/3 ml-3">
 			<%= abymize(:tasks, f, limit: 3, partial: 'projects/task_fields') do |abyme| %>
         <%= abyme.records(order: {created_at: :asc}, wrapper_html: { class: "persisted-tasks" }) %>
-				<%= abyme.new_records(position: :end, wrapper_html: {class: "new-tasks"}, fields_html: {class: "test"}) %>
+				<%= abyme.new_records(position: :end, wrapper_html: {class: "new-tasks", data: { target: 'wrapper-target', controller: 'wrapper-controller' }}, fields_html: {class: "random-field-class", data: { target: 'sub-target', controller: 'sub-controller' }}) %>
 				<%= add_association(content: 'Add task', html: { id: 'add-task', class: 'border-solid border-2 rounded border-grey-300 bg-white rounded-b lg:rounded-b-none lg:rounded-r p-4 flex flex-col justify-center items-center leading-normal p-8 my-5 cursor-pointer w-full focus:outline-none' }) %>
 			<% end %>
 		</div>

--- a/app/views/projects/_form.html.erb
+++ b/app/views/projects/_form.html.erb
@@ -20,7 +20,10 @@
 		</div>
 		<div class="container bg-white p-8 w-2/3 ml-3">
 			<%= abymize(:tasks, f, limit: 3, partial: 'projects/task_fields') do |abyme| %>
-        <%= abyme.records(order: {created_at: :asc}, wrapper_html: { class: "persisted-tasks" }) %>
+				<%= abyme.records(order: {created_at: :asc},
+					wrapper_html: { class: "persisted-tasks", data: { controller: "tasks-wrapper" } },
+					fields_html: { class: "persisted-fields", data: { target: "tasks-wrapper.test" } }
+				) %>
 				<%= abyme.new_records(position: :end, 
 					wrapper_html: { class: "new-tasks", data: { target: 'wrapper-target', controller: 'tasks-wrapper' } },
 					fields_html: {class: "test", data: { target: 'sub-target', controller: 'sub-controller' } }

--- a/lib/abyme/view_helpers.rb
+++ b/lib/abyme/view_helpers.rb
@@ -99,12 +99,12 @@ module Abyme
     end
 
     def build_attibutes(default, attr)
-      # ADD NEW DATA ATTRIBUTES VALUES TO THE DEFAULT ONES
+      # ADD NEW DATA ATTRIBUTES VALUES TO THE DEFAULT ONES (ONLY VALUES)
       default[:data].each do |key, value|
         default[:data][key] = "#{value} #{attr[:data][key]}".strip if attr[:data]
       end
 
-      # ADD NEW DATA ATTRIBUTES
+      # ADD NEW DATA ATTRIBUTES (KEYS & VALUES)
       if attr[:data]
         default[:data] = default[:data].merge(attr[:data].reject { |key, _| default[:data][key] })
       end

--- a/lib/abyme/view_helpers.rb
+++ b/lib/abyme/view_helpers.rb
@@ -19,12 +19,21 @@ module Abyme
 
     def new_records_for(association, form, options = {}, &block)
       options[:wrapper_html] ||= {}
-      content_tag(:div, options[:wrapper_html].merge(
-        data: { target: 'abyme.associations', association: association, abyme_position: options[:position] || :end }
-        )) do
+
+      wrapper_default = { 
+        data: { 
+          target: 'abyme.associations', 
+          association: association, 
+          abyme_position: options[:position] || :end 
+        } 
+      }
+
+      fields_default = { data: { target: 'abyme.fields abyme.newFields' } }
+
+      content_tag(:div, build_attibutes(wrapper_default, options[:wrapper_html])) do
         content_tag(:template, class: "abyme--#{association.to_s.singularize}_template", data: { target: 'abyme.template' }) do
           form.fields_for association, association.to_s.classify.constantize.new, child_index: 'NEW_RECORD' do |f|
-            content_tag(:div, basic_fields_markup(options[:fields_html], association).merge(data: { target: 'abyme.fields abyme.newFields' })) do
+            content_tag(:div, build_attibutes(fields_default, basic_fields_markup(options[:fields_html], association))) do
               # Here, if a block is passed, we're passing the association fields to it, rather than the form itself
               block_given? ? yield(f) : render("abyme/#{association.to_s.singularize}_fields", f: f)
             end
@@ -87,6 +96,21 @@ module Abyme
         html[:class] = "abyme--fields #{association.to_s.singularize}-fields"
       end
       html
+    end
+
+    def build_attibutes(default, attr)
+      # ADD NEW DATA ATTRIBUTES VALUES TO THE DEFAULT ONES
+      default[:data].each do |key, value|
+        default[:data][key] = "#{value} #{attr[:data][key]}".strip if attr[:data]
+      end
+
+      # ADD NEW DATA ATTRIBUTES
+      if attr[:data]
+        default[:data] = default[:data].merge(attr[:data].reject { |key, _| default[:data][key] })
+      end
+
+      # MERGE THE DATA ATTRIBUTES TO THE HASH OF HTML ATTRIBUTES
+      default.merge(attr.reject { |key, _| key == :data })
     end
   end
 end

--- a/lib/abyme/view_helpers.rb
+++ b/lib/abyme/view_helpers.rb
@@ -30,10 +30,10 @@ module Abyme
 
       fields_default = { data: { target: 'abyme.fields abyme.newFields' } }
 
-      content_tag(:div, build_attibutes(wrapper_default, options[:wrapper_html])) do
+      content_tag(:div, build_attributes(wrapper_default, options[:wrapper_html])) do
         content_tag(:template, class: "abyme--#{association.to_s.singularize}_template", data: { target: 'abyme.template' }) do
           form.fields_for association, association.to_s.classify.constantize.new, child_index: 'NEW_RECORD' do |f|
-            content_tag(:div, build_attibutes(fields_default, basic_fields_markup(options[:fields_html], association))) do
+            content_tag(:div, build_attributes(fields_default, basic_fields_markup(options[:fields_html], association))) do
               # Here, if a block is passed, we're passing the association fields to it, rather than the form itself
               block_given? ? yield(f) : render("abyme/#{association.to_s.singularize}_fields", f: f)
             end
@@ -98,17 +98,15 @@ module Abyme
       html
     end
 
-    def build_attibutes(default, attr)
+    def build_attributes(default, attr)
       # ADD NEW DATA ATTRIBUTES VALUES TO THE DEFAULT ONES (ONLY VALUES)
-      default[:data].each do |key, value|
-        default[:data][key] = "#{value} #{attr[:data][key]}".strip if attr[:data]
-      end
-
-      # ADD NEW DATA ATTRIBUTES (KEYS & VALUES)
       if attr[:data]
+        default[:data].each do |key, value|
+          default[:data][key] = "#{value} #{attr[:data][key]}".strip
+        end
+      # ADD NEW DATA ATTRIBUTES (KEYS & VALUES)
         default[:data] = default[:data].merge(attr[:data].reject { |key, _| default[:data][key] })
       end
-
       # MERGE THE DATA ATTRIBUTES TO THE HASH OF HTML ATTRIBUTES
       default.merge(attr.reject { |key, _| key == :data })
     end

--- a/lib/abyme/view_helpers.rb
+++ b/lib/abyme/view_helpers.rb
@@ -45,17 +45,18 @@ module Abyme
     def persisted_records_for(association, form, options = {})
       records = options[:collection] || form.object.send(association)
       options[:wrapper_html] ||= {}
+      fields_default = { data: { target: 'abyme.fields' } }
       
       if options[:order].present?
         records = records.order(options[:order])
         # Get invalid records
         invalids = form.object.send(association).reject(&:persisted?)
         records = records.to_a.concat(invalids) if invalids.any?
-      end
+      end 
       
       content_tag(:div, options[:wrapper_html]) do
         form.fields_for(association, records) do |f|
-          content_tag(:div, basic_fields_markup(options[:fields_html], association).merge(data: { target: 'abyme.fields' })) do
+          content_tag(:div, build_attributes(fields_default, basic_fields_markup(options[:fields_html], association))) do
             block_given? ? yield(f) : render("abyme/#{association.to_s.singularize}_fields", f: f)
           end
         end

--- a/spec/system/abyme_options_spec.rb
+++ b/spec/system/abyme_options_spec.rb
@@ -72,6 +72,12 @@ RSpec.describe "Helper options" do
       2.times { click_on('Add task') }
       expect(find_all('.test').length).to eq(2)
     end
+
+    it 'should allow data-attributes to be passed to the wrapper' do
+      visit new_project_path
+      click_on('Add task')
+      expect(find('.new-tasks[data-controller="tasks-wrapper"]')).not_to be_nil
+    end
   
     it 'should set the correct inner text for the add association button' do
       visit new_project_path

--- a/spec/system/abyme_options_spec.rb
+++ b/spec/system/abyme_options_spec.rb
@@ -1,103 +1,144 @@
 require "rails_helper"
 RSpec.describe "Helper options" do
-  describe "Partials default & custom path", type: :system do
-    it 'should set the correct partial when path specified' do
-      visit new_project_path
-      add_tasks(1)
-      element = find('.custom-partial')
-      expect(element).not_to be_nil
+  context 'For new resources' do
+    describe "Partials default & custom path", type: :system do
+      it 'should set the correct partial when path specified' do
+        visit new_project_path
+        add_tasks(1)
+        element = find('.custom-partial')
+        expect(element).not_to be_nil
+      end
+    
+      it 'should set the correct partial when path not specified' do
+        visit new_project_path
+        click_on('add participant')
+        within('#abyme--participants') do
+          expect(".abyme--fields").not_to be_nil
+        end
+      end
+    end
+    
+    describe "Render error feedback", type: :system do
+      it 'should render error feedback for main resource' do
+        visit new_project_path
+        fill_in('project_description', with: 'A project description')
+        click_on('Save')
+        save_and_open_page
+        element = find('.error')
+        expect(element).not_to be_nil
+      end
+    
+      it 'should render error feedback for nested resources' do
+        visit new_project_path
+        fill_in('project_title', with: "A project with two tasks")
+        fill_in('project_description', with: 'A project description')
+        add_tasks(1)
+        add_tasks_with_errors(1)
+        click_on('Save')
+        save_and_open_page
+        element = find('.error')
+        expect(element).not_to be_nil
+      end
     end
   
-    it 'should set the correct partial when path not specified' do
-      visit new_project_path
-      click_on('add participant')
-      within('#abyme--participants') do
-        expect(".abyme--fields").not_to be_nil
+    describe "HTML attributes for 'abyme-fields' & add/remove association", type: :system do
+      it 'should create the correct id' do
+        visit new_project_path
+        element = find('#add-task')
+        expect(element).not_to be_nil
+      end
+    
+      it 'should create the correct classes' do 
+        visit new_project_path
+        click_on('add participant')
+        element = find('.participant-fields')
+        expect(element).not_to be_nil
+      end
+    
+      it 'should add the base classes "abyme--fields" and "association-fields' do
+        visit new_project_path
+        click_on('add participant')
+        element = find('.abyme--fields.participant-fields')
+        expect(element).not_to be_nil
+      end
+  
+      it 'should allow HTML to be passed to the wrapper' do
+        visit new_project_path
+        click_on('Add task')
+        expect(find('.new-tasks')).not_to be_nil
+      end
+  
+      it 'should allow HTML to be passed to each field' do
+        visit new_project_path
+        2.times { click_on('Add task') }
+        expect(find_all('.test').length).to eq(2)
+      end
+  
+      it 'should allow data-attributes to be passed to the wrapper' do
+        visit new_project_path
+        click_on('Add task')
+        expect(find('.new-tasks[data-controller="tasks-wrapper"]')).not_to be_nil
+      end
+  
+      it 'should allow data-attributes to be passed to the fields without overwriting the defaults' do
+        visit new_project_path
+        click_on('Add task')
+        expect(find('.test[data-target="abyme.fields abyme.newFields sub-target"]')).not_to be_nil
+      end
+    
+      it 'should set the correct inner text for the add association button' do
+        visit new_project_path
+        element = find('button', text: 'add participant')
+        expect(element).not_to be_nil
+      end
+  
+      it 'should not create more than 3 tasks' do
+        visit new_project_path
+        4.times { click_on('Add task') }
+        task_fields = []
+        within('#abyme--tasks') { expect(all('.task-fields').length).to eq(3) }
+      end
+      
+      it 'should display 1 default empty comment per task' do
+        visit new_project_path
+        click_on('Add task')
+        within('#abyme--comments') do
+          expect(find('.comment-fields')).not_to be_nil
+        end 
       end
     end
   end
-  
-  describe "Render error feedback", type: :system do
-    it 'should render error feedback for main resource' do
-      visit new_project_path
-      fill_in('project_description', with: 'A project description')
-      click_on('Save')
-      save_and_open_page
-      element = find('.error')
-      expect(element).not_to be_nil
-    end
-  
-    it 'should render error feedback for nested resources' do
-      visit new_project_path
-      fill_in('project_title', with: "A project with two tasks")
-      fill_in('project_description', with: 'A project description')
-      add_tasks(1)
-      add_tasks_with_errors(1)
-      click_on('Save')
-      save_and_open_page
-      element = find('.error')
-      expect(element).not_to be_nil
-    end
-  end
 
-  describe "HTML attributes for 'abyme-fields' & add/remove association", type: :system do
-    it 'should create the correct id' do
-      visit new_project_path
-      element = find('#add-task')
-      expect(element).not_to be_nil
+  context "With existing tasks" do
+    before(:all) do
+      @project = create(:project)
+      3.times { |n| @project.tasks.create!(title: "task #{n}", description: "who cares") }
     end
-  
-    it 'should create the correct classes' do 
-      visit new_project_path
-      click_on('add participant')
-      element = find('.participant-fields')
-      expect(element).not_to be_nil
-    end
-  
+
     it 'should add the base classes "abyme--fields" and "association-fields' do
-      visit new_project_path
-      click_on('add participant')
-      element = find('.abyme--fields.participant-fields')
-      expect(element).not_to be_nil
+      visit edit_project_path(@project)
+      elements = find_all('.abyme--fields.task-fields')
+      expect(elements).not_to be_empty
     end
 
     it 'should allow HTML to be passed to the wrapper' do
-      visit new_project_path
-      click_on('Add task')
-      expect(find('.new-tasks')).not_to be_nil
+      visit edit_project_path(@project)
+      expect(find('.persisted-tasks')).not_to be_nil
     end
 
-    it 'should allow HTML to be passed to each field' do
-      visit new_project_path
-      2.times { click_on('Add task') }
-      expect(find_all('.test').length).to eq(2)
+    it 'should allow HTML to be passed to each field withot overwriting defaults' do
+      visit edit_project_path(@project)
+      expect(find_all('.abyme--fields.task-fields.persisted-fields')).not_to be_empty
     end
 
     it 'should allow data-attributes to be passed to the wrapper' do
-      visit new_project_path
-      click_on('Add task')
-      expect(find('.new-tasks[data-controller="tasks-wrapper"]')).not_to be_nil
-    end
-  
-    it 'should set the correct inner text for the add association button' do
-      visit new_project_path
-      element = find('button', text: 'add participant')
-      expect(element).not_to be_nil
+      visit edit_project_path(@project)
+      expect(find('.persisted-tasks[data-controller="tasks-wrapper"]')).not_to be_nil
     end
 
-    it 'should not create more than 3 tasks' do
-      visit new_project_path
-      4.times { click_on('Add task') }
-      task_fields = []
-      within('#abyme--tasks') { expect(all('.task-fields').length).to eq(3) }
-    end
-    
-    it 'should display 1 default empty comment per task' do
-      visit new_project_path
-      click_on('Add task')
-      within('#abyme--comments') do
-        expect(find('.comment-fields')).not_to be_nil
-      end 
+    it 'should allow data-attributes to be passed to the fields without overwriting the defaults' do
+      visit edit_project_path(@project)
+      expect(find('.persisted-fields[data-target="abyme.fields tasks-wrapper.test"]')).not_to be_nil
     end
   end
 end


### PR DESCRIPTION
Made the `html` options able to pass data-attributes without overriding defaults.

Also covered some more tests for `persisted` options.